### PR TITLE
Fix artifact upload for compile_c

### DIFF
--- a/.github/workflows/compile_c.yml
+++ b/.github/workflows/compile_c.yml
@@ -43,7 +43,7 @@ jobs:
           gcc c/main.c -o target/wrongsecrets-c-linux
       - name: Uploading executables
         uses: actions/upload-artifact@v3
-        if: failure()
+        if: always()
         with:
           name: executables
           path: target/*


### PR DESCRIPTION
Compile_c.yml was only uploading the binaries on failure. This should be happening always.