### PR TITLE
Adding stripping of binaries on local builds to actually use these instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,34 +61,15 @@ dockcross-windows-static-x64
 
 #Binaries themselves
 wrongsecrets-advanced-c
-wrongsecrets-advanced-c-arm
-wrongsecrets-advanced-c-linux
-wrongsecrets-advanced-c-linux-arm
-wrongsecrets-advanced-c-linux-musl
-wrongsecrets-advanced-c-linux-musl-arm
+wrongsecrets-advanced-c-*
 wrongsecrets-c
-wrongsecrets-c-arm
-wrongsecrets-c-linux
-wrongsecrets-c-linux-arm
-wrongsecrets-c-linux-musl
-wrongsecrets-c-linux-musl-arm
+wrongsecrets-c-*
 wrongsecrets-cplus
-wrongsecrets-cplus-arm
-wrongsecrets-cplus-linux
-wrongsecrets-cplus-linux-arm
-wrongsecrets-cplus-linux-musl
-wrongsecrets-cplus-linux-musl-arm
+wrongsecrets-cplus-*
 wrongsecrets-golang
-wrongsecrets-golang-arm
-wrongsecrets-golang-linux
-wrongsecrets-golang-linux-arm
+wrongsecrets-golang-*
 wrongsecrets-rust
-wrongsecrets-rust-arm
-wrongsecrets-rust-linux
-wrongsecrets-rust-linux-arm
-wrongsecrets-rust-linux-musl
-wrongsecrets-rust-linux-musl-arm
-
+wrongsecrets-rust-*
 
 dockcross/
 .vscode/

--- a/quickbuild.sh
+++ b/quickbuild.sh
@@ -40,6 +40,22 @@ echo "prerequired: ln -s /usr/local/opt/musl-cross/bin/x86_64-linux-musl-gcc /us
 x86_64-linux-musl-gcc c/main.c -o wrongsecrets-c-linux-musl
 x86_64-linux-musl-gcc c/advanced/advanced.c -o wrongsecrets-advanced-c-linux-musl
 
+echo "stripping"
+cp wrongsecrets-advanced-c wrongsecrets-advanced-c-stripped
+strip -S wrongsecrets-advanced-c-stripped
+cp wrongsecrets-advanced-c-arm wrongsecrets-advanced-c-arm-stripped
+strip -S wrongsecrets-advanced-c-arm-stripped
+cp wrongsecrets-advanced-c-linux wrongsecrets-advanced-c-linux-stripped
+strip -S wrongsecrets-advanced-c-linux-stripped
+cp wrongsecrets-advanced-c-linux-arm wrongsecrets-advanced-c-linux-arm-stripped
+strip -S wrongsecrets-advanced-c-linux-arm-stripped
+cp wrongsecrets-advanced-c-windows wrongsecrets-advanced-c-windows-stripped
+strip -S wrongsecrets-advanced-c-windows-stripped
+cp wrongsecrets-advanced-c-linux-musl wrongsecrets-advanced-c-linux-musl-stripped
+strip -S wrongsecrets-advanced-c-linux-musl-stripped
+cp wrongsecrets-advanced-c-linux-musl-arm wrongsecrets-advanced-c-linux-musl-arm-stripped
+strip -S wrongsecrets-advanced-c-linux-musl-arm-stripped
+
 
 echo "Compiling C++"
 echo "Compiling C++ for Intel Macos-X"


### PR DESCRIPTION

 <!-- Thank you for submitting a pull request to the WrongSecrets Binaries repo! See what makes a good PR at https://github.com/OWASP/wrongsecrets-binaries/blob/master/CONTRIBUTING.md-->

### What kind of changes does this PR include?

-   [x] Fixes or refactors: reduces footprint
-   [ ] A new challenge
-   [ ] Additional documentation
-   [ ] Something else

#### Description

<!---
Please provide a helpful summary of what change this pull request will introduce.
--->

### Relations

Closes #11 as this is the final stripping part

### References

<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Checklist:

-   [x] All the contributions made are solely the work of me and my co-authors
-   [x] I tested the changes in this PR (if applicable)
-   [x] Quickbuild.sh is extended to compile the binary for all target environnments
-   [ ] Github actions are implemented to publish the new challenge
-   [x] A spoil command is implemented to return the actual answer
-   [x] The correct and incorrect answer strings are compliant with Contributing.md.
-   [ ] The PR passes pre-commit hooks and automated tests
