### PR TITLE
fix quickbuildissues

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -1,5 +1,4 @@
 CC = gcc
-CFLAGS = -Wall -Wextra
 SRC = main.c
 OUT = main
 CPPCHECK = cppcheck

--- a/cplus/Makefile
+++ b/cplus/Makefile
@@ -1,5 +1,4 @@
-CXX = gcc
-CXXFLAGS = -Wall -Wextra
+CXX = g++
 SRC = main.cpp
 OUT = main
 CPPCHECK = cppcheck

--- a/quickbuild.sh
+++ b/quickbuild.sh
@@ -4,11 +4,11 @@ echo "Please run this on Mac OS-X with GCC support for 'arm64-apple-macos12' and
 
 echo "Compiling C"
 echo "Compiling C for Intel Macos-X"
-(cd c && make CFLAGS+='-target x86_64-apple-macos12' OUT='wrongsecrets-c')
-(cd c/advanced && make CFLAGS+='-target x86_64-apple-macos12' OUT='wrongsecrets-advanced-c')
+(cd c && make CFLAGS+='-target x86_64-apple-macos12' OUT='../wrongsecrets-c')
+(cd c/advanced && make CFLAGS+='-target x86_64-apple-macos12 ' OUT='../../wrongsecrets-advanced-c')
 echo "Compiling C for ARM Macos-X"
-(cd c && make CFLAGS+='-target arm64-apple-macos12' OUT='wrongsecrets-c-arm')
-(cd c/advanced && make CFLAGS+='-target arm64-apple-macos12' OUT='wrongsecrets-advanced-c-arm')
+(cd c && make CFLAGS+='-target arm64-apple-macos12' OUT='../wrongsecrets-c-arm')
+(cd c/advanced && make CFLAGS+='-target arm64-apple-macos12' OUT='../../wrongsecrets-advanced-c-arm')
 echo "Compiling C for ARM-linux, based on https://github.com/dockcross/dockcross"
 echo "prerequired: git clone https://github.com/dockcross/dockcross.git"
 echo "prerequired: cd dockcross"
@@ -59,9 +59,9 @@ strip -S wrongsecrets-advanced-c-linux-musl-arm-stripped
 
 echo "Compiling C++"
 echo "Compiling C++ for Intel Macos-X"
-(cd cplus && make CXXFLAGS+='-target x86_64-apple-macos12' OUT='wrongsecrets-cplus')
+(cd cplus && make CXXFLAGS+='-target x86_64-apple-macos12' OUT='../wrongsecrets-cplus')
 echo "Compiling C++ for ARM Macos-X"
-(cd cplus && make CXXFLAGS+='-target arm64-apple-macos12' OUT='wrongsecrets-cplus-arm')
+(cd cplus && make CXXFLAGS+='-target arm64-apple-macos12' OUT='../wrongsecrets-cplus-arm')
 echo "Compiling C++ for ARM, based on https://github.com/dockcross/dockcross"
 ./dockcross-linux-arm64-lts bash -c '$CC cplus/main.cpp -lstdc++ -o wrongsecrets-cplus-linux-arm'
 echo "Compiling C++ for linux"


### PR DESCRIPTION
 <!-- Thank you for submitting a pull request to the WrongSecrets Binaries repo! See what makes a good PR at https://github.com/OWASP/wrongsecrets-binaries/blob/master/CONTRIBUTING.md-->

### What kind of changes does this PR include?

-   [X] Fixes or refactors: fixes quickbuild issues for the makefile calls
-   [ ] A new challenge
-   [ ] Additional documentation
-   [ ] Something else

#### Description

<!---
Please provide a helpful summary of what change this pull request will introduce.
--->

### Relations

<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or
Closes #0000
--->

### References

<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Checklist:

-   [x] All the contributions made are solely the work of me and my co-authors
-   [x] I tested the changes in this PR (if applicable)
-   [ ] I added unit tests to ensure my change works (when change in Java or on front-end code)
-   [ ] Quickbuild.sh is extended to compile the binary for all target environnments
-   [ ] Github actions are implemented to publish the new challenge
-   [ ] A spoil command is implemented to return the actual answer
-   [ ] The correct and incorrect answer strings are compliant with Contributing.md.
-   [x] The PR passes pre-commit hooks and automated tests
