### PR TITLE
Split CodeQL analysis into two jobs: one for Swift (macOS) and one fo…

### DIFF
--- a/.github/workflows/security-scanning.yml
+++ b/.github/workflows/security-scanning.yml
@@ -34,7 +34,7 @@ jobs:
           - language: 'java'
             build-mode: manual
           - language: 'rust'
-            build-mode: autobuild
+            build-mode: none
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/security-scanning.yml
+++ b/.github/workflows/security-scanning.yml
@@ -18,30 +18,23 @@ permissions:
 
 jobs:
   codeql-analysis:
-    name: CodeQL Analysis
+    name: CodeQL Analysis (Non-Swift)
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        language: ['c-cpp', 'go', 'csharp', 'java', 'rust', 'swift']
+        language: ['c-cpp', 'go', 'csharp', 'java', 'rust']
         include:
           - language: 'c-cpp'
             build-mode: manual
-            runs-on: ubuntu-latest
           - language: 'go'
             build-mode: autobuild
-            runs-on: ubuntu-latest
           - language: 'csharp'
             build-mode: manual
-            runs-on: ubuntu-latest
           - language: 'java'
             build-mode: manual
-            runs-on: ubuntu-latest
           - language: 'rust'
             build-mode: autobuild
-            runs-on: ubuntu-latest
-          - language: 'swift'
-            build-mode: manual
-            runs-on: macos-latest
 
     steps:
       - name: Checkout repository
@@ -65,12 +58,6 @@ jobs:
         with:
           java-version: '26'
           distribution: 'temurin'
-
-      - name: Setup Swift
-        if: matrix.language == 'swift'
-        uses: SwiftyLab/setup-swift@38f54a76b70d989321de9dc7c840618c08cf56e9
-        with:
-          swift-version: '6.2.0'
 
       - name: Setup Rust
         if: matrix.language == 'rust'
@@ -107,17 +94,49 @@ jobs:
           cd ../obfuscated
           ./mvnw compile -q
 
-      - name: Manual build for Swift
-        if: matrix.language == 'swift'
-        run: |
-          cd swift
-          swift build -c release
-
       - name: Manual build for Rust
         if: matrix.language == 'rust'
         run: |
           cd rust
           cargo build --release
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938
+        with:
+          category: "/language:${{matrix.language}}"
+
+  codeql-swift-analysis:
+    name: CodeQL Analysis (Swift)
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['swift']
+        include:
+          - language: 'swift'
+            build-mode: manual
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Setup Swift
+        if: matrix.language == 'swift'
+        uses: SwiftyLab/setup-swift@38f54a76b70d989321de9dc7c840618c08cf56e9
+        with:
+          swift-version: '6.2.0'
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Manual build for Swift
+        if: matrix.language == 'swift'
+        run: |
+          cd swift
+          swift build -c release
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938


### PR DESCRIPTION
…r rest (Ubuntu)

- codeql-analysis: Handles c-cpp, go, csharp, java, rust on ubuntu-latest
- codeql-swift-analysis: New job for Swift on macos-latest
- semgrep-analysis: Unchanged

This separation ensures Swift runs on macOS runners where the toolchain is available, while all other languages continue to run on Ubuntu runners.

Generated by Mistral Vibe.

 <!-- Thank you for submitting a pull request to the WrongSecrets Binaries repo! See what makes a good PR at https://github.com/OWASP/wrongsecrets-binaries/blob/master/CONTRIBUTING.md-->

### What kind of changes does this PR include?

-   [x] Fixes or refactors
-   [ ] A new challenge
-   [ ] Additional documentation
-   [ ] Something else

#### Description

<!---
Please provide a helpful summary of what change this pull request will introduce.
--->

### Relations

<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or
Closes #0000
--->

### References

<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Checklist:

-   [ ] All the contributions made are solely the work of me and my co-authors
-   [ ] I tested the changes in this PR (if applicable)
-   [ ] I added unit tests to ensure my change works (when change in Java or on front-end code)
-   [ ] Quickbuild.sh is extended to compile the binary for all target environnments
-   [ ] Github actions are implemented to publish the new challenge
-   [ ] A spoil command is implemented to return the actual answer
-   [ ] The correct and incorrect answer strings are compliant with Contributing.md.
-   [ ] The PR passes pre-commit hooks and automated tests
